### PR TITLE
Upgrade to Gridsome 0.5.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,6 @@
     "@gridsome/remark-prismjs": "0.0.4",
     "@gridsome/source-filesystem": "^0.2.0",
     "@gridsome/transformer-remark": "^0.1.3",
-    "gridsome": "^0.4.5"
+    "gridsome": "^0.5.7"
   }
 }


### PR DESCRIPTION
Gridsome's 0.5.0 update back in [Feb 2019](https://github.com/gridsome/gridsome/commit/7ffe88f3a3f0941e19d81956e44abd5c65e2bd86) fixed an issue that I'm currently having with this starter. 
[`Error: write EPIPE at WriteWrap.afterWrite [as oncomplete] (net.js:844:14)`](https://github.com/gridsome/gridsome/issues/199)

I have already tested and everything is functioning.